### PR TITLE
More course recommendation updates

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -16,7 +16,8 @@ class CourseController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('dev.users.only')->except(['index', 'completedForm', 'markAsCompleted']);
+        $this->middleware('dev.users.only')
+             ->except(['index', 'recommendations', 'recommendationResults']);
     }
 
     /**

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -215,7 +215,7 @@ class CourseController extends Controller
         // insert concurrent course directly after the course it is concurrent with
         foreach ($this->findCoursesThatCanBeRecommendedAsConcurrent($suggestedCourses, $semester) as $course) {
             $index = $suggestedCourses->search(Course::find($course->concurrents[0]));
-            $suggestedCourses->splice($index, 0, [$course]);
+            $suggestedCourses->splice($index + 1, 0, [$course]);
         }
 
         return $suggestedCourses;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -13,7 +13,7 @@ class UserController extends Controller
     public function completedForm()
     {
         $pageName = "Mark Completed Courses";
-        $courses = Course::all();
+        $courses = Course::orderBy('abbreviation')->get()->all();
         $currentCompletedCourses = auth()->user()->completedCourses()->pluck('course_id')->toArray();
 
         return view('mark-completed',

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3481,8 +3481,8 @@ var Navigation = /*#__PURE__*/function (_React$Component) {
           className: "mr-6",
           key: x
         }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("a", {
-          className: "".concat(window.location.href.indexOf(link.uri) !== -1 ? 'text-blue-800 font-medium cursor-text' : 'text-gray-700 hover:text-blue-600'),
-          href: "".concat(window.location.href.indexOf(link.uri) === -1 ? "".concat(link.uri) : '#')
+          className: "".concat(window.location.href.indexOf(link.uri) === -1 || window.location.href.indexOf("/courses/") !== -1 ? 'text-gray-500 hover:text-blue-800' : 'text-blue-800 font-medium cursor-text'),
+          href: "".concat(window.location.href.indexOf(link.uri) === -1 || window.location.href.indexOf("/courses/") !== -1 ? "".concat(link.uri) : '#')
         }, link.name));
       });
       return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("ul", {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3478,8 +3478,8 @@ var Navigation = /*#__PURE__*/function (_React$Component) {
           className: "mr-6",
           key: x
         }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("a", {
-          className: "".concat(window.location.href.indexOf(link.uri) !== -1 ? 'text-gray-500 cursor-text' : 'text-blue-800 hover:text-blue-600'),
-          href: "".concat(link.uri)
+          className: "".concat(window.location.href.indexOf(link.uri) !== -1 ? 'text-blue-800 font-medium cursor-text' : 'text-gray-700 hover:text-blue-600'),
+          href: "".concat(window.location.href.indexOf(link.uri) === -1 ? "".concat(link.uri) : '#')
         }, link.name));
       });
       return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("ul", {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3176,7 +3176,10 @@ function model() {
             prereq.childCourses = [];
           }
 
-          prereq.childCourses.push(course);
+          if (!course.concurrents || course.concurrents.indexOf(courseId) < 0) {
+            prereq.childCourses.push(course);
+          }
+
           return prereq;
         });
       }

--- a/resources/js/components/Navigation.js
+++ b/resources/js/components/Navigation.js
@@ -17,7 +17,8 @@ class Navigation extends React.Component {
         const navLinks = this.nav.links.map( (link, x) => {
             return (
                 <li className="mr-6" key={x}>
-                    <a className={`${window.location.href.indexOf(link.uri) !== -1 ? 'text-gray-500 cursor-text' : 'text-blue-800 hover:text-blue-600'}`} href={`${link.uri}`}>{link.name}</a>
+                    <a className={`${window.location.href.indexOf(link.uri) !== -1 ? 'text-blue-800 font-medium cursor-text' : 'text-gray-700 hover:text-blue-600'}`}
+                       href={`${window.location.href.indexOf(link.uri) === -1 ? `${link.uri}` : '#'}`}>{link.name}</a>
                 </li>
             )
         });

--- a/resources/js/components/Navigation.js
+++ b/resources/js/components/Navigation.js
@@ -17,8 +17,10 @@ class Navigation extends React.Component {
         const navLinks = this.nav.links.map( (link, x) => {
             return (
                 <li className="mr-6" key={x}>
-                    <a className={`${window.location.href.indexOf(link.uri) !== -1 ? 'text-blue-800 font-medium cursor-text' : 'text-gray-700 hover:text-blue-600'}`}
-                       href={`${window.location.href.indexOf(link.uri) === -1 ? `${link.uri}` : '#'}`}>{link.name}</a>
+                    <a className={`${window.location.href.indexOf(link.uri) === -1 || window.location.href.indexOf("/courses/") !== -1
+                        ? 'text-gray-500 hover:text-blue-800' : 'text-blue-800 font-medium cursor-text'}`}
+                       href={`${window.location.href.indexOf(link.uri) === -1 || window.location.href.indexOf("/courses/") !== -1
+                           ? `${link.uri}` : '#'}`}>{link.name}</a>
                 </li>
             )
         });

--- a/resources/views/mark-completed.blade.php
+++ b/resources/views/mark-completed.blade.php
@@ -7,7 +7,7 @@
         <form action="{{route('markAsCompleted')}}" method="post">
             @csrf
 
-            <div class="grid grid-cols-3 gap-4 ">
+            <div class="grid grid-cols-4 gap-2">
 
             @foreach($courses as $course)
 

--- a/tests/Feature/CourseRecommendationsTest.php
+++ b/tests/Feature/CourseRecommendationsTest.php
@@ -36,16 +36,16 @@ class CourseRecommendationsTest extends TestCase
         $this->courseOne->semesters()->attach([1, 2]);
 
 
-        $courseTwoPrerequisites = ["1"];
+        $courseTwoPrerequisites = [$this->getCourseId(1)];
         $this->courseTwo = Course::factory()->create(
             ['title' => 'Test Course Two', 'abbreviation' => 'Test 311', 'type' => 'Test',
-             'semester_specific' => true, 'prerequisites_for_count' => 2,
+             'semester_specific' => false, 'prerequisites_for_count' => 2,
                 'prerequisites' => $courseTwoPrerequisites]);
-        $this->courseTwo->semesters()->attach([2]);
+        $this->courseTwo->semesters()->attach([1, 2]);
 
 
-        $courseThreePrerequisites = ["2"];
-        $courseThreeConcurrents = ["2"];
+        $courseThreePrerequisites = [$this->getCourseId(2)];
+        $courseThreeConcurrents = [$this->getCourseId(2)];
         $this->courseThree = Course::factory()->create(
             ['title' => 'Test Course Three', 'abbreviation' => 'Test 432', 'type' => 'Test',
              'semester_specific' => false, 'prerequisites_for_count' => 1,
@@ -53,15 +53,15 @@ class CourseRecommendationsTest extends TestCase
         $this->courseThree->semesters()->attach([1, 3]);
 
 
-        $courseFourPrerequisites = ["3"];
+        $courseFourPrerequisites = [$this->getCourseId(3)];
         $this->courseFour = Course::factory()->create(
             ['title' => 'Test Course Four', 'abbreviation' => 'Test 512', 'type' => 'Test',
-             'semester_specific' => false, 'prerequisites_for_count' => 0,
+             'semester_specific' => true, 'prerequisites_for_count' => 0,
              'prerequisites' => $courseFourPrerequisites]);
-        $this->courseFour->semesters()->attach([1,3]);
+        $this->courseFour->semesters()->attach([1]);
 
 
-        $courseFivePrerequisites = ["1"];
+        $courseFivePrerequisites = [$this->getCourseId(1)];
         $this->courseFive = Course::factory()->create(
             ['title' => 'Test Course Five', 'abbreviation' => 'Test 661', 'type' => 'Test',
              'semester_specific' => true, 'prerequisites_for_count' => 1,
@@ -69,19 +69,21 @@ class CourseRecommendationsTest extends TestCase
         $this->courseFive->semesters()->attach([1]);
 
 
-        $courseSixPrerequisites = ["2", "5"];
+        $courseSixPrerequisites = [$this->getCourseId(2), $this->getCourseId(5)];
         $this->courseSix = Course::factory()->create(
-            ['title' => 'Test Course Five', 'abbreviation' => 'Test 654', 'type' => 'Test',
+            ['title' => 'Test Course Six', 'abbreviation' => 'Test 654', 'type' => 'Test',
              'semester_specific' => false, 'prerequisites_for_count' => 0,
              'prerequisites' => $courseSixPrerequisites]);
         $this->courseSix->semesters()->attach([2, 3]);
+
     }
 
     /**  @test */
     public function correct_courses_are_recommended_1()
     {
         // no completed courses
-        // $this->user->completedCourses()->sync([]);
+
+        // only one course to recommend (course 1) b/c of semester and pre-req limits
 
         $data = ["semester" => 1, 'number_of_courses' => 2];
 
@@ -98,16 +100,188 @@ class CourseRecommendationsTest extends TestCase
     public function correct_courses_are_recommended_2()
     {
         // completed course one
-        $this->user->completedCourses()->sync([1]);
+        $this->user->completedCourses()->sync([$this->getCourseId(1)]);
+
+        // only one course to recommend (course 2) b/c of semester and pre-req limits
+
+        $this->user->fresh();
+
+        $data = ["semester" => 2, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Two");
+        $response->assertDontSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_3()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1)]);
+
+        // two courses can be recommended, (courses 2 or 5) b/c of 2 having a higher pre-req-for count, it is chosen
+
+        $this->user->fresh();
+
+        $data = ["semester" => 1, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Two");
+        $response->assertDontSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+
+    }
+
+
+    /**  @test */
+    public function correct_courses_are_recommended_4()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1)]);
+
+        // three courses can be recommended, (courses 2, 3 or 5) but the
+        // requests only asks for two b/c of 2 having a higher pre-req-for count, it is chosen
+        // and then b/c course three is a concurrent for course two it is also recommended over 5
+
+        $this->user->fresh();
 
         $data = ["semester" => 1, 'number_of_courses' => 2];
 
         $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
 
         $response->assertSuccessful();
-        $response->assertSee("Test Course One");
-        $response->assertSee("We could not find enough available courses to meet
+        $response->assertSee("Test Course Two");
+        $response->assertDontSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+        $response->assertSee("Test 432 can only be taken as a concurrent if you also take Test 311!");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_5()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1), $this->getCourseId(2),
+            $this->getCourseId(3)]);
+
+        // two courses to recommend (course 4 and course 5) b/c of semester and pre-req limits and b/c course 5 offers
+        // a higher pre-req for count (they are also both semester specific so that's a tie) it is recommended
+
+        $this->user->fresh();
+
+        $data = ["semester" => 1, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Five");
+        $response->assertDontSee("We could not find enough available courses to meet
             the number of courses you requested due to limitation of course offerings and prerequisites.");
 
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_6()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1), $this->getCourseId(2),
+            $this->getCourseId(3)]);
+
+        // two courses to recommend (course 4 and course 5) b/c of semester and pre-req limits and b/c course 5 offers
+        // a higher pre-req for count (they are also both semester specific so that's a tie) it is recommended
+
+        $this->user->fresh();
+
+        $data = ["semester" => 1, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Five");
+        $response->assertDontSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_7()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1), $this->getCourseId(2),
+            $this->getCourseId(5)]);
+
+        // b/c of semester chosen course three will be recommended, in a diff semester course 6 would be recommended
+
+        $this->user->fresh();
+
+        $data = ["semester" => 1, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Three");
+        $response->assertDontSee("Sorry, we couldn't find any courses that fit your criteria...");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_8()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1), $this->getCourseId(2),
+            $this->getCourseId(5)]);
+
+        // only course 6 can be recommended so it is
+
+        $this->user->fresh();
+
+        $data = ["semester" => 2, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course Six");
+        $response->assertDontSee("Sorry, we couldn't find any courses that fit your criteria...");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_9()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([$this->getCourseId(1)]);
+
+        // no courses to recommend b/c of semester and pre-req limits
+
+        $this->user->fresh();
+
+        $data = ["semester" => 3, 'number_of_courses' => 1];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertDontSee("Test Course Two");
+        $response->assertSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+        $response->assertSee("Sorry, we couldn't find any courses that fit your criteria...", false);
+
+    }
+
+    private function getCourseId($logicalCourseId)
+    {
+        return match ($logicalCourseId) {
+            1 => Course::where("title", "Test Course One")->first()->id,
+            2 => Course::where("title", "Test Course Two")->first()->id,
+            3 => Course::where("title", "Test Course Three")->first()->id,
+            4 => Course::where("title", "Test Course Four")->first()->id,
+            5 => Course::where("title", "Test Course Five")->first()->id,
+            default => Course::where("title", "Test Course Six")->first()->id,
+        };
     }
 }

--- a/tests/Feature/CourseRecommendationsTest.php
+++ b/tests/Feature/CourseRecommendationsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Course;
+use App\Models\User;
+use Database\Seeders\SemesterSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CourseRecommendationsTest extends TestCase
+{
+    protected $seed = true;
+    protected $seeder = SemesterSeeder::class;
+
+    use RefreshDatabase;
+
+    private $user;
+    private $courseOne;
+    private $courseTwo;
+    private $courseThree;
+    private $courseFour;
+    private $courseFive;
+    private $courseSix;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['name' => 'Jessica Tester', 'email' => 'jessica@psu.edu']);
+
+
+        $this->courseOne = Course::factory()->create(
+            ['title' => 'Test Course One', 'abbreviation' => 'Test 221', 'type' => 'Test',
+             'semester_specific' => false, 'prerequisites_for_count' => 2
+            ]);
+        $this->courseOne->semesters()->attach([1, 2]);
+
+
+        $courseTwoPrerequisites = ["1"];
+        $this->courseTwo = Course::factory()->create(
+            ['title' => 'Test Course Two', 'abbreviation' => 'Test 311', 'type' => 'Test',
+             'semester_specific' => true, 'prerequisites_for_count' => 2,
+                'prerequisites' => $courseTwoPrerequisites]);
+        $this->courseTwo->semesters()->attach([2]);
+
+
+        $courseThreePrerequisites = ["2"];
+        $courseThreeConcurrents = ["2"];
+        $this->courseThree = Course::factory()->create(
+            ['title' => 'Test Course Three', 'abbreviation' => 'Test 432', 'type' => 'Test',
+             'semester_specific' => false, 'prerequisites_for_count' => 1,
+             'prerequisites' => $courseThreePrerequisites, 'concurrents' => $courseThreeConcurrents]);
+        $this->courseThree->semesters()->attach([1, 3]);
+
+
+        $courseFourPrerequisites = ["3"];
+        $this->courseFour = Course::factory()->create(
+            ['title' => 'Test Course Four', 'abbreviation' => 'Test 512', 'type' => 'Test',
+             'semester_specific' => false, 'prerequisites_for_count' => 0,
+             'prerequisites' => $courseFourPrerequisites]);
+        $this->courseFour->semesters()->attach([1,3]);
+
+
+        $courseFivePrerequisites = ["1"];
+        $this->courseFive = Course::factory()->create(
+            ['title' => 'Test Course Five', 'abbreviation' => 'Test 661', 'type' => 'Test',
+             'semester_specific' => true, 'prerequisites_for_count' => 1,
+             'prerequisites' => $courseFivePrerequisites]);
+        $this->courseFive->semesters()->attach([1]);
+
+
+        $courseSixPrerequisites = ["2", "5"];
+        $this->courseSix = Course::factory()->create(
+            ['title' => 'Test Course Five', 'abbreviation' => 'Test 654', 'type' => 'Test',
+             'semester_specific' => false, 'prerequisites_for_count' => 0,
+             'prerequisites' => $courseSixPrerequisites]);
+        $this->courseSix->semesters()->attach([2, 3]);
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_1()
+    {
+        // no completed courses
+        // $this->user->completedCourses()->sync([]);
+
+        $data = ["semester" => 1, 'number_of_courses' => 2];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course One");
+        $response->assertSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+
+    }
+
+    /**  @test */
+    public function correct_courses_are_recommended_2()
+    {
+        // completed course one
+        $this->user->completedCourses()->sync([1]);
+
+        $data = ["semester" => 1, 'number_of_courses' => 2];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertSuccessful();
+        $response->assertSee("Test Course One");
+        $response->assertSee("We could not find enough available courses to meet
+            the number of courses you requested due to limitation of course offerings and prerequisites.");
+
+    }
+}

--- a/tests/Feature/CourseRecommendationsTest.php
+++ b/tests/Feature/CourseRecommendationsTest.php
@@ -79,6 +79,19 @@ class CourseRecommendationsTest extends TestCase
     }
 
     /**  @test */
+    public function correct_courses_are_not_recommended_without_entering_the_number_of_courses()
+    {
+
+        $data = ["semester" => 1, 'number_of_courses' => null];
+
+        $response = $this->actingAs($this->user)->from(route('recommendations'))->post(route('recommendationResults', $data));
+
+        $response->assertRedirect(route('recommendations'));
+        $response->assertSessionHasErrorsIn('number_of_courses');
+
+    }
+
+    /**  @test */
     public function correct_courses_are_recommended_1()
     {
         // no completed courses

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -19,7 +19,7 @@ class RegisterTest extends TestCase
 
         $response = $this->post('register', $data);
 
-        $response->assertRedirect(route('home'));
+        $response->assertRedirect(route('courses.index'));
 
         $this->assertDatabaseHas('users', ["name" => "Jennifer Student", "email" => "jnr332@psu.edu"]);
     }


### PR DESCRIPTION
#### Purpose 
Added new tests for the course recommendations and tweaked the aesthetics on the nav and mark as completed views

#### Tests
```
   PASS  Tests\Feature\CourseRecommendationsTest
  ✓ correct courses are not recommended without entering the number of courses
  ✓ correct courses are recommended 1
  ✓ correct courses are recommended 2
  ✓ correct courses are recommended 3
  ✓ correct courses are recommended 4
  ✓ correct courses are recommended 5
  ✓ correct courses are recommended 6
  ✓ correct courses are recommended 7
  ✓ correct courses are recommended 8
  ✓ correct courses are recommended 9

   PASS  Tests\Feature\CourseTest
  ✓ auth user can visit courses index
  ✓ auth user sees correct courses on courses index
  ✓ guest can not visit courses index
  ✓ dev auth user can visit create course
  ✓ non dev auth user can not visit create course
  ✓ guest can not visit create course
  ✓ dev auth user can visit edit course
  ✓ non dev auth user can not visit edit course
  ✓ guest can not visit edit course
  ✓ dev auth user can create a course
  ✓ dev auth user can create a course with prerequisites
  ✓ dev auth user can create a course with concurrents
  ✓ dev auth user can create a course with prerequisites and concurrents
  ✓ dev auth user can not create a course with a course title already taken
  ✓ dev auth user can not create a course with a course abbreviation already taken
  ✓ dev auth user can not create a course with no description
  ✓ dev auth user can not create a course with invalid number of credits
  ✓ dev auth user can not create a course with invalid semester choice
  ✓ dev auth user can not create a course with invalid concurrents choice
  ✓ dev auth user can not create a course with invalid prerequisites choice
  ✓ regular auth user can not create a course
  ✓ guest can not create a course
  ✓ dev auth user can update a course
  ✓ dev auth user can update a course with prerequisites
  ✓ dev auth user can update a course with concurrents and prerequisites
  ✓ dev auth user can not update a course with a course title already taken
  ✓ dev auth user can not update a course with a course abbreviation already taken
  ✓ dev auth user can not update a course with no description
  ✓ dev auth user can not update a course with invalid number of credits
  ✓ dev auth user can not update a course with invalid semester choice
  ✓ dev auth user can not update a course with invalid concurrents choice
  ✓ dev auth user can not update a course with invalid prerequisites choice
  ✓ regular auth user can not update a course
  ✓ guest can not update a course
  ✓ dev auth user can delete a course
  ✓ when dev auth user deletes a course it is removed as a prerequisite from other courses
  ✓ regular auth user can not delete a course
  ✓ guest can not delete a course

   PASS  Tests\Feature\RegisterTest
  ✓ guest can register for the site
  ✓ guest can not register with out a penn state email address

  Tests:  50 passed
  Time:   4.63s
```